### PR TITLE
Fix relay rules configmap name in deployment

### DIFF
--- a/charts/maildev/Chart.yaml
+++ b/charts/maildev/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: maildev
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.1.0
 type: application
 description: SMTP Server + Web Interface for viewing and testing emails during development.

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
       volumes:
       - name: auto-relay-rules
         configMap:
-          name: maildev-relay-rules
+          name: {{ include "maildev.fullname" . }}-relay-rules
           items:
           - key: auto-relay-rules.json
             path: auto-relay-rules.json


### PR DESCRIPTION
Currently, the name of the relay rules configmap is parametric in it's template, but there is a static configmap name in deployment's volume reference. This PR changes the reference to same value as in configmap template.