### PR TITLE
Fix configuration values

### DIFF
--- a/charts/maildev/README.md
+++ b/charts/maildev/README.md
@@ -30,11 +30,11 @@ Not listing here the more general paramaters such as tolerations, nodeSelectors,
 
 | Parameter                     | Description                                                                                       | Default                                     |
 |------------------------------:|:--------------------------------------------------------------------------------------------------|:--------------------------------------------|
-| **outgoing_relay.host**       | SMTP Relay host, `MAILDEV_OUTGOING_HOST`.                                                         | ``                                          |
-| **outgoing_relay.port**       | SMTP Relay port, `MAILDEV_OUTGOING_PORT`.                                                         | ``                                          |
-| **outgoing_relay.user**       | SMTP Relay user, `MAILDEV_OUTGOING_USER`.                                                         | ``                                          |
-| **outgoing_relay.pass**       | SMTP Relay password, `MAILDEV_OUTGOING_PASS`.                                                     | ``                                          |
-| **outgoing_relay.secure**     | Use SMTP SSL for outgoing emails, `MAILDEV_OUTGOING_SECURE`.                                      | `true`. Hardcoded in the deployment due to a bug. |
+| **outgoingRelay.host**       | SMTP Relay host, `MAILDEV_OUTGOING_HOST`.                                                         | ``                                          |
+| **outgoingRelay.port**       | SMTP Relay port, `MAILDEV_OUTGOING_PORT`.                                                         | ``                                          |
+| **outgoingRelay.user**       | SMTP Relay user, `MAILDEV_OUTGOING_USER`.                                                         | ``                                          |
+| **outgoingRelay.pass**       | SMTP Relay password, `MAILDEV_OUTGOING_PASS`.                                                     | ``                                          |
+| **outgoingRelay.secure**     | Use SMTP SSL for outgoing emails, `MAILDEV_OUTGOING_SECURE`.                                      | `true`. Hardcoded in the deployment due to a bug. |
 | **ports.smtp**                | Port where the SMTP service is listening. (Irrelevant for OCP/K8S), `MAILDEV_SMTP_PORT`.          | `1025`                                      |
 | **ports.web**                 | Port where the Web interface service is listening. (Irrelevant for OCP/K8S), `MAILDEV_WEB_PORT`.  | `1080`                                      |
 | **web.disable**               | Disable Web interface. `MAILDEV_DISABLE_WEB`.                                                     | `false`                                     |

--- a/charts/maildev/templates/cm-auto-relay-rules.yaml
+++ b/charts/maildev/templates/cm-auto-relay-rules.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.outgoingRelay.autoRelay.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,4 +6,5 @@ metadata:
   labels:
     {{- include "maildev.labels" . | nindent 4 }}
 data:
-  auto-relay-rules.json: "[\n\t{ \"allow\": \"*\" }\n]\n"
+  auto-relay-rules.json: '{{ .Values.outgoingRelay.autoRelay.rules | toJson }}'
+{{- end -}}

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -11,10 +11,11 @@ spec:
       {{- include "maildev.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        checksum/cm-auto-relay-rules: {{ include (print $.Template.BasePath "/cm-auto-relay-rules.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "maildev.selectorLabels" . | nindent 8 }}
     spec:
@@ -30,8 +31,19 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/usr/src/app/bin/maildev"]
-          args: ["--verbose", "--outgoing-secure", "--auto-relay"]
+          args:
+          {{- if .Values.verbose }}
+          - "--verbose"
+          {{- end }}
+          {{- if .Values.outgoingRelay.autoRelay.enabled }}
+          - "--auto-relay"
+          {{- end }}
+          {{- if .Values.outgoingRelay.secure }}
+          - "--outgoing-secure"
+          {{- end }}
+          {{- if .Values.web.disable }}
+          - "--disable-web"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: smtp-port
@@ -41,8 +53,6 @@ spec:
             containerPort: {{ .Values.ports.web }}
             protocol: TCP
           env:
-          - name: MAILDEV_DISABLE_WEB
-            value: "{{ .Values.web.disable }}"
           {{- if or .Values.web.user .Values.web.pass}}
           - name: MAILDEV_WEB_USER
             value: "{{ .Values.web.user }}"
@@ -55,24 +65,32 @@ spec:
             value: "{{ .Values.ports.web }}"
           - name: MAILDEV_HTTPS
             value: "{{ .Values.https.enabled }}"
-          {{- if .Values.https.key }}
+          {{- if .Values.https.enabled }}
           - name: MAILDEV_HTTPS_KEY
             value: "{{ .Values.https.key }}"
-          {{- end }}
-          {{- if .Values.https.cert }}
           - name: MAILDEV_HTTPS_CERT
             value:  "{{ .Values.https.cert }}"
           {{- end }}
+          {{- if .Values.outgoingRelay.host }}
           - name: MAILDEV_OUTGOING_HOST
-            value: "{{ .Values.outgoing_relay.host }}"
+            value: "{{ .Values.outgoingRelay.host }}"
+          {{- end }}
+          {{- if .Values.outgoingRelay.port }}
           - name: MAILDEV_OUTGOING_PORT
-            value: "{{ .Values.outgoing_relay.port }}"
+            value: "{{ .Values.outgoingRelay.port }}"
+          {{- end }}
+          {{- if .Values.outgoingRelay.user }}
           - name: MAILDEV_OUTGOING_USER
-            value: "{{ .Values.outgoing_relay.user }}"
+            value: "{{ .Values.outgoingRelay.user }}"
+          {{- end }}
+          {{- if .Values.outgoingRelay.pass }}
           - name: MAILDEV_OUTGOING_PASS
-            value: "{{ .Values.outgoing_relay.pass }}"
-          - name: MAILDEV_OUTGOING_SECURE
-            value: "{{ .Values.outgoing_relay.secure }}"
+            value: "{{ .Values.outgoingRelay.pass }}"
+          {{- end }}
+          {{- if and .Values.outgoingRelay.autoRelay.enabled .Values.outgoingRelay.autoRelay.receiver }}
+          - name: MAILDEV_AUTO_RELAY
+            value: "{{ .Values.outgoingRelay.autoRelay.receiver }}"
+          {{- end }}
           {{- if .Values.incoming }}
           - name: MAILDEV_INCOMING_USER
             value: "{{ .Values.incoming.user }}"
@@ -89,6 +107,7 @@ spec:
               port: {{ .Values.ports.web }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.outgoingRelay.autoRelay.enabled }}
           volumeMounts:
           - name: auto-relay-rules
             mountPath: /etc/maildev
@@ -100,6 +119,7 @@ spec:
           items:
           - key: auto-relay-rules.json
             path: auto-relay-rules.json
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -87,9 +87,13 @@ spec:
           - name: MAILDEV_OUTGOING_PASS
             value: "{{ .Values.outgoingRelay.pass }}"
           {{- end }}
-          {{- if and .Values.outgoingRelay.autoRelay.enabled .Values.outgoingRelay.autoRelay.receiver }}
+          {{- if .Values.outgoingRelay.autoRelay.enabled }}
+          - name: MAILDEV_AUTO_RELAY_RULES
+            value: /etc/maildev/auto-relay-rules.json
+          {{- if .Values.outgoingRelay.autoRelay.receiver }}
           - name: MAILDEV_AUTO_RELAY
             value: "{{ .Values.outgoingRelay.autoRelay.receiver }}"
+          {{- end }}
           {{- end }}
           {{- if .Values.incoming }}
           - name: MAILDEV_INCOMING_USER
@@ -111,14 +115,10 @@ spec:
           volumeMounts:
           - name: auto-relay-rules
             mountPath: /etc/maildev
-            subPath: auto-relay-rules.json
       volumes:
       - name: auto-relay-rules
         configMap:
           name: maildev-relay-rules
-          items:
-          - key: auto-relay-rules.json
-            path: auto-relay-rules.json
 {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/maildev/values.yaml
+++ b/charts/maildev/values.yaml
@@ -4,25 +4,32 @@ image:
   repository: maildev/maildev
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 1.1.0
+  tag: 2.0.0-beta3
 
-outgoing_relay:
-  # MAILDEV_OUTGOING_HOST
-  host: smtp.gmail.com
-   # MAILDEV_OUTGOING_PORT
-  port: 465
-   # MAILDEV_OUTGOING_USER
-  user: 'XXX'
-   # MAILDEV_OUTGOING_PASS
-  pass: 'YYY'
-  # MAILDEV_OUTGOING_SECURE
-  secure: true
+verbose: false
 
-incoming:
-  # MAILDEV_INCOMING_USER
-  # user:
-  # MAILDEV_INCOMING_PASS
-  # pass:
+outgoingRelay:
+  # # MAILDEV_OUTGOING_HOST
+  # host: smtp.gmail.com
+  # # MAILDEV_OUTGOING_PORT
+  # port: 465
+  # # MAILDEV_OUTGOING_USER
+  # user: 'XXX'
+  # # MAILDEV_OUTGOING_PASS
+  # pass: 'YYY'
+  # secure: false
+  autoRelay:
+    enabled: false
+    # MAILDEV_AUTO_RELAY
+    # receiver: test
+    rules:
+      - allow: '*'
+
+incoming: {}
+  # # MAILDEV_INCOMING_USER
+  #  user:
+  # # MAILDEV_INCOMING_PASS
+  #  pass:
 
 ports:
   # MAILDEV_SMTP_PORT
@@ -30,22 +37,21 @@ ports:
   # MAILDEV_WEB_PORT
   web: 1080
 
-# MAILDEV_HTTPS
+## MAILDEV_HTTPS
 https:
   enabled: false
-  # MAILDEV_HTTPS_KEY
+  # # MAILDEV_HTTPS_KEY
   # key:
-  # MAILDEV_HTTPS_KEY
+  # # MAILDEV_HTTPS_KEY
   # cert:
 
 # Web interface
 web:
-  # MAILDEV_DISABLE_WEB
   disable: false
-  # MAILDEV_WEB_USER
-  user: admin
-  # MAILDEV_WEB_PASS
-  pass: admin
+  # # MAILDEV_WEB_USER
+  # user: admin
+  # # MAILDEV_WEB_PASS
+  # pass: admin
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
For version 1.1.0 environment vars were not working so we update to
2.0.0-beta3.
Also boolean values were not working and we added them as args.
Furthermore, auto relay rules were writed in YAML and only create
configmap if needed.