### PR TITLE
Simplify configuration

### DIFF
--- a/charts/maildev/Chart.yaml
+++ b/charts/maildev/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: maildev
-version: 0.1.3
-appVersion: 1.1.0
+version: 0.2.0
+appVersion: 2.0.5
 type: application
 description: SMTP Server + Web Interface for viewing and testing emails during development.
 keywords:

--- a/charts/maildev/README.md
+++ b/charts/maildev/README.md
@@ -12,39 +12,26 @@ MailDev also provides a Web interface, it can be disabled/enabled at discretion.
 Also note that mails do not persist after reboot. Everytime MailDev starts, it starts from scratch,
 even if the `/tmp/maildev` folder, where MailDev stores mails, is persisted.
 
-## Sources code
+## Source code
 
 MailDev source code can be found here: https://github.com/maildev/maildev.
 
 ## Known issue with Env Vars
 
-GitHub issue: https://github.com/maildev/maildev/issues/315
-
-So, not every option can be configured using env vars, so, a few options are hardcoded in the deployment:
-`["--verbose", "--outgoing-secure", "--auto-relay"]`
+GitHub issue: https://github.com/maildev/maildev/issues/315 . Configure the affected options using **args** instead.
 
 ## Configuration
 
-Table with the most relevant parameters for MailDev.
+Table with the most relevant parameters for MailDev. All other parameters can be configured by either overriding
+the arguments using **args** or by providing and environment variable using **env**. See the [Usage section](https://github.com/maildev/maildev#usage)
+in the MailDev repo for all available options.
+
 Not listing here the more general paramaters such as tolerations, nodeSelectors, etc.
 
-| Parameter                     | Description                                                                                       | Default                                     |
-|------------------------------:|:--------------------------------------------------------------------------------------------------|:--------------------------------------------|
-| **outgoing_relay.host**       | SMTP Relay host, `MAILDEV_OUTGOING_HOST`.                                                         | ``                                          |
-| **outgoing_relay.port**       | SMTP Relay port, `MAILDEV_OUTGOING_PORT`.                                                         | ``                                          |
-| **outgoing_relay.user**       | SMTP Relay user, `MAILDEV_OUTGOING_USER`.                                                         | ``                                          |
-| **outgoing_relay.pass**       | SMTP Relay password, `MAILDEV_OUTGOING_PASS`.                                                     | ``                                          |
-| **outgoing_relay.secure**     | Use SMTP SSL for outgoing emails, `MAILDEV_OUTGOING_SECURE`.                                      | `true`. Hardcoded in the deployment due to a bug. |
-| **ports.smtp**                | Port where the SMTP service is listening. (Irrelevant for OCP/K8S), `MAILDEV_SMTP_PORT`.          | `1025`                                      |
-| **ports.web**                 | Port where the Web interface service is listening. (Irrelevant for OCP/K8S), `MAILDEV_WEB_PORT`.  | `1080`                                      |
-| **web.disable**               | Disable Web interface. `MAILDEV_DISABLE_WEB`.                                                     | `false`                                     |
-| **web.user**                  | Web interface user, `MAILDEV_WEB_USER`.                                                           | `admin`                                     |
-| **web.pass**                  | Web interface password, `MAILDEV_WEB_PASS`.                                                       | ``                                          |
-| **https.enabled**             | Switch from http to https protocol, `MAILDEV_HTTPS`.                                              | `false`                                     |
-| **https.key**                 | The file path to the ssl private key, `MAILDEV_HTTPS_KEY`.                                        |                                             |
-| **https.cert**                | The file path to the ssl cert file, `MAILDEV_HTTPS_CERT`.                                         |                                             |
-| **incoming.user**             | SMTP user for incoming emails, `MAILDEV_INCOMING_USER`.                                           |                                             |
-| **incoming.pass**             | SMTP password for incoming emails, `MAILDEV_INCOMING_PASS`.                                       |                                             |
+| Parameter                     | Description                                                                                       | Default |
+|------------------------------:|:--------------------------------------------------------------------------------------------------|:--------|
+| **ports.smtp**                | Port where the SMTP service is listening. (Irrelevant for OCP/K8S), `MAILDEV_SMTP_PORT`.          | `1025`  |
+| **ports.web**                 | Port where the Web interface service is listening. (Irrelevant for OCP/K8S), `MAILDEV_WEB_PORT`.  | `1080`  |
 
 ## Test it
 

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -30,8 +30,12 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/usr/src/app/bin/maildev"]
-          args: ["--verbose", "--outgoing-secure", "--auto-relay"]
+          {{- if .Values.command }}
+          command: {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: smtp-port
@@ -41,43 +45,13 @@ spec:
             containerPort: {{ .Values.ports.web }}
             protocol: TCP
           env:
-          - name: MAILDEV_DISABLE_WEB
-            value: "{{ .Values.web.disable }}"
-          {{- if or .Values.web.user .Values.web.pass}}
-          - name: MAILDEV_WEB_USER
-            value: "{{ .Values.web.user }}"
-          - name: MAILDEV_WEB_PASS
-            value: "{{ .Values.web.pass }}"
-          {{- end }}
           - name: MAILDEV_SMTP_PORT
             value: "{{ .Values.ports.smtp }}"
           - name: MAILDEV_WEB_PORT
             value: "{{ .Values.ports.web }}"
-          - name: MAILDEV_HTTPS
-            value: "{{ .Values.https.enabled }}"
-          {{- if .Values.https.key }}
-          - name: MAILDEV_HTTPS_KEY
-            value: "{{ .Values.https.key }}"
-          {{- end }}
-          {{- if .Values.https.cert }}
-          - name: MAILDEV_HTTPS_CERT
-            value:  "{{ .Values.https.cert }}"
-          {{- end }}
-          - name: MAILDEV_OUTGOING_HOST
-            value: "{{ .Values.outgoing_relay.host }}"
-          - name: MAILDEV_OUTGOING_PORT
-            value: "{{ .Values.outgoing_relay.port }}"
-          - name: MAILDEV_OUTGOING_USER
-            value: "{{ .Values.outgoing_relay.user }}"
-          - name: MAILDEV_OUTGOING_PASS
-            value: "{{ .Values.outgoing_relay.pass }}"
-          - name: MAILDEV_OUTGOING_SECURE
-            value: "{{ .Values.outgoing_relay.secure }}"
-          {{- if .Values.incoming }}
-          - name: MAILDEV_INCOMING_USER
-            value: "{{ .Values.incoming.user }}"
-          - name: MAILDEV_INCOMING_PASS
-            value:  "{{ .Values.incoming.pass }}"
+          {{- range $name, $value := .Values.env }}
+          - name: {{ $name }}
+            value: {{ $value }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/maildev/values.yaml
+++ b/charts/maildev/values.yaml
@@ -3,49 +3,27 @@ replicaCount: 1
 image:
   repository: maildev/maildev
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: 1.1.0
+  # tag: 2.0.5
 
-outgoing_relay:
-  # MAILDEV_OUTGOING_HOST
-  host: smtp.gmail.com
-   # MAILDEV_OUTGOING_PORT
-  port: 465
-   # MAILDEV_OUTGOING_USER
-  user: 'XXX'
-   # MAILDEV_OUTGOING_PASS
-  pass: 'YYY'
-  # MAILDEV_OUTGOING_SECURE
-  secure: true
+# command:
+args:
+- --verbose
 
-incoming:
-  # MAILDEV_INCOMING_USER
-  # user:
-  # MAILDEV_INCOMING_PASS
-  # pass:
+env:
+  # MAILDEV_OUTGOING_HOST: smtp.gmail.com
+  # MAILDEV_OUTGOING_PORT: 465
+  # MAILDEV_OUTGOING_USER: "XXX"
+  # MAILDEV_OUTGOING_PASS: "YYY"
+  # MAILDEV_INCOMING_USER: ""
+  # MAILDEV_INCOMING_PASS: ""
+  # MAILDEV_WEB_USER: "admin"
+  # MAILDEV_WEB_PASS: "admin"
 
 ports:
   # MAILDEV_SMTP_PORT
   smtp: 1025
   # MAILDEV_WEB_PORT
   web: 1080
-
-# MAILDEV_HTTPS
-https:
-  enabled: false
-  # MAILDEV_HTTPS_KEY
-  # key:
-  # MAILDEV_HTTPS_KEY
-  # cert:
-
-# Web interface
-web:
-  # MAILDEV_DISABLE_WEB
-  disable: false
-  # MAILDEV_WEB_USER
-  user: admin
-  # MAILDEV_WEB_PASS
-  pass: admin
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
I've opted to simplify the configuration of this Chart by directly exposing the command, arguments and environment variables. Specifically allowing configuration of the arguments allows the user to work around the env var issue. This change also makes the Chart compatible the latest MailDev 2.x version.

This change breaks backwards compatibility, so I've also bumped the Chart version.