### PR TITLE
Make probe path configurable and document maildev 3.x opt-in

### DIFF
--- a/charts/maildev/Chart.yaml
+++ b/charts/maildev/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: maildev
-version: 0.2.0
+version: 0.3.0
 appVersion: 2.2.1
 type: application
 description: SMTP Server + Web Interface for viewing and testing emails during development.

--- a/charts/maildev/README.md
+++ b/charts/maildev/README.md
@@ -23,6 +23,8 @@ Not listing here the more general paramaters such as tolerations, nodeSelectors,
 
 | Parameter                            | Description                                                                                       | Default                                     |
 |-------------------------------------:|:--------------------------------------------------------------------------------------------------|:--------------------------------------------|
+| **image.tag**                        | maildev image tag; defaults to the chart appVersion. Set to a 3.x tag to opt in (see below).     | `""` (appVersion)                           |
+| **probePath**                        | HTTP path for the liveness/readiness probes. Use `/` for maildev 3.x (which removed `/healthz`).  | `/healthz`                                  |
 | **verbose**                          | Enable verbose logging, `--verbose`.                                                             | `false`                                     |
 | **extraArgs**                        | Extra CLI args appended after the chart-generated flags, for options not modelled below.         | `[]`                                        |
 | **extraEnv**                         | Extra container env vars (list of `name`/`value` or `valueFrom` entries), for options not modelled below. | `[]`                              |
@@ -44,6 +46,21 @@ Not listing here the more general paramaters such as tolerations, nodeSelectors,
 | **https.cert**                | The file path to the ssl cert file, `MAILDEV_HTTPS_CERT`.                                         |                                             |
 | **incoming.user**             | SMTP user for incoming emails, `MAILDEV_INCOMING_USER`.                                           |                                             |
 | **incoming.pass**             | SMTP password for incoming emails, `MAILDEV_INCOMING_PASS`.                                       |                                             |
+
+## Trying maildev 3.x
+
+The chart defaults to the latest stable maildev (2.x). maildev 3.x is a
+rewrite and currently only ships a release candidate, so it is not the
+default. It removed the `/healthz` endpoint the probes use, so opting in
+requires pointing the probes at `/`:
+
+```yaml
+image:
+  tag: "3.0.0-rc.1"
+probePath: "/"
+```
+
+The chart's flags and env vars are otherwise compatible with 3.x.
 
 ## Test it
 

--- a/charts/maildev/templates/deployment.yaml
+++ b/charts/maildev/templates/deployment.yaml
@@ -109,11 +109,11 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.probePath }}
               port: {{ .Values.ports.web }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.probePath }}
               port: {{ .Values.ports.web }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/maildev/values.yaml
+++ b/charts/maildev/values.yaml
@@ -3,7 +3,9 @@ replicaCount: 1
 image:
   repository: maildev/maildev
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart appVersion (2.2.1).
+  # To try the 3.x release candidate, set tag: "3.0.0-rc.1" and probePath: "/"
+  # (3.x is a rewrite that removed the /healthz endpoint).
   tag: ""
 
 # Enable verbose logging (--verbose).
@@ -57,6 +59,11 @@ ports:
   smtp: 1025
   # MAILDEV_WEB_PORT
   web: 1080
+
+# HTTP path used by the liveness/readiness probes. maildev 2.x serves
+# "/healthz"; the 3.x rewrite removed it, so set this to "/" when running a
+# 3.x image (see image.tag).
+probePath: /healthz
 
 # MAILDEV_HTTPS
 https:


### PR DESCRIPTION
## Context

Follow-up to the question of defaulting the chart to maildev 3.x. Investigation found:

- **3.0.0-rc.1's flags/env are compatible** with the chart (`--verbose`, `--auto-relay`, `--outgoing-secure`, ports all work; no `MAILDEV_HTTPS`-style truthiness trap).
- **But 3.x is a rewrite that removed the `/healthz` endpoint.** On `3.0.0-rc.1`, `/healthz` → 404 and only `/` → 200. Since the probes hardcode `/healthz`, a bare `image.tag: 3.0.0-rc.1` would crashloop.
- It's also a **release candidate**, so it shouldn't be the default for a published chart.

## Change

- Keep **2.2.1 as the default** appVersion.
- Add a **`probePath`** value (default `/healthz`, so 2.x behavior is unchanged) used by both the liveness and readiness probes.
- Document the 3.x opt-in in `values.yaml` and a new README section:

  ```yaml
  image:
    tag: "3.0.0-rc.1"
  probePath: "/"
  ```

- Chart version `0.2.0 → 0.3.0` (additive, backward-compatible).

## Verification

- `helm lint` → 0 failures.
- Default render: `image: maildev/maildev:2.2.1`, probes `path: /healthz`.
- `--set image.tag=3.0.0-rc.1 --set probePath=/`: `image: maildev/maildev:3.0.0-rc.1`, probes `path: /`.
- Confirmed against the real image: `3.0.0-rc.1` serves `/` → 200 (and `/healthz` → 404), 2.2.1 serves `/healthz` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)